### PR TITLE
Fixed IE10 dataset incompatibility

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -46,17 +46,17 @@ var Component = _react2["default"].createClass({
 
         var el = this.refs.element;
 
-        el.dataset.state = "hidden";
+        el.setAttribute('data-state', 'hidden');
         el.offsetHeight;
-        el.dataset.state = "";
+        el.setAttribute('data-state', '');
         el.offsetHeight;
-        el.dataset.state = "running";
+        el.setAttribute('data-state', 'running');
     },
 
     hide: function hide() {
         if (--this.count > 0) return;
 
-        this.refs.element.dataset.state = "finishing";
+        this.refs.element.setAttribute('data-state', "finishing");
         this.hidingTimerId = setTimeout(this.toHiddenState, 500);
     },
 
@@ -66,7 +66,7 @@ var Component = _react2["default"].createClass({
     },
 
     toHiddenState: function toHiddenState() {
-        this.refs.element.dataset.state = "hidden";
+        this.refs.element.setAttribute('data-state', "hidden");
     },
 
     componentWillMount: function componentWillMount() {
@@ -78,7 +78,7 @@ var Component = _react2["default"].createClass({
     },
 
     isVisible: function isVisible() {
-        return this.refs.element.dataset.state != "hidden";
+        return this.refs.element.getAttribute('data-state') != "hidden";
     }
 });
 

--- a/src/main.js
+++ b/src/main.js
@@ -35,18 +35,18 @@ var Component = React.createClass({
 
         var el = this.refs.element;
 
-        el.dataset.state = "hidden";
+        el.setAttribute('data-state', 'hidden');
         el.offsetHeight;
-        el.dataset.state = "";
+        el.setAttribute('data-state', '');
         el.offsetHeight;
-        el.dataset.state = "running";
+        el.setAttribute('data-state', 'running');
     },
 
     hide() {
         if(-- this.count > 0)
             return ;
 
-        this.refs.element.dataset.state = "finishing";
+        this.refs.element.setAttribute('data-state', "finishing");
         this.hidingTimerId = setTimeout(this.toHiddenState, 500);
     },
 
@@ -56,7 +56,7 @@ var Component = React.createClass({
     },
 
     toHiddenState() {
-        this.refs.element.dataset.state = "hidden";
+        this.refs.element.setAttribute('data-state', "hidden");
     },
 
     componentWillMount() {
@@ -68,7 +68,7 @@ var Component = React.createClass({
     },
 
     isVisible() {
-        return this.refs.element.dataset.state != "hidden";
+        return this.refs.element.getAttribute('data-state') != "hidden";
     }
 });
 


### PR DESCRIPTION
The .dataset property is not available in IE10 or older, so it is necessary to use the .setAttribute() and .getAttribute() methods.
