### PR TITLE
Could not click on any other HTML elements while progress bar was shown

### DIFF
--- a/main.css
+++ b/main.css
@@ -29,8 +29,6 @@
   z-index: 99999999;
   top: 0;
   left: 0;
-  width: 100%;
-  height: 100%;
 }
 
 .loader-60devs[data-state="running"] .loader-60devs-progress {


### PR DESCRIPTION
When the progress bar was shown it was not possible to click on any other HTML elements, and in practice this was blocking the rest of my application since I could not click on any other elements to trigger new actions. 

To fix this I removed the width:100% and heigh:100% properties on the data-state=running attribute on the ::before pseudo-class, so that the element does not cover the whole viewport. Unsure if it would be better to remove the whole ::before pseudo-class, but I'm guessing there's a reason why it's needed.

For me it was essential that I could trigger new actions in my application while the progress bar was running.
