### PR TITLE
Use callback ref instead of string ref (supports preact)

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -21,7 +21,7 @@ let Component = React.createClass({
         let cls = `loader-60devs ${this.props.cls}`
 
         return (
-            <div className={cls} data-state={this.state.state} ref="element">
+            <div className={cls} data-state={this.state.state} ref=(element => { this.element = element })>
                 <div className="loader-60devs-progress"></div>
             </div>
         )
@@ -33,7 +33,7 @@ let Component = React.createClass({
 
         clearTimeout(this.hidingTimerId)
 
-        var {element} = this.refs
+        var {element} = this
         let progressEl = element.querySelector('.loader-60devs-progress')
 
         element.setAttribute('data-state', 'hidden')
@@ -49,7 +49,7 @@ let Component = React.createClass({
         if(-- this.count > 0)
             return 
 
-        this.refs.element.setAttribute('data-state', 'finishing')
+        this.element.setAttribute('data-state', 'finishing')
         this.hidingTimerId = setTimeout(this.toHiddenState, 500)
     },
 
@@ -59,7 +59,7 @@ let Component = React.createClass({
     },
 
     toHiddenState() {
-        this.refs.element.setAttribute('data-state', 'hidden')
+        this.element.setAttribute('data-state', 'hidden')
     },
 
     componentWillMount() {
@@ -71,7 +71,7 @@ let Component = React.createClass({
     },
 
     isVisible() {
-        return this.refs.element.getAttribute('data-state') != 'hidden'
+        return this.element.getAttribute('data-state') != 'hidden'
     }
 })
 


### PR DESCRIPTION
Tiny change to make use of callback refs instead of string refs to support preact (which has no string ref support) and future react versions that might drop string ref support.