### PR TITLE
Clear timeout if component is unmounted

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -73,6 +73,7 @@ class Component extends React.Component {
 	}
 
 	componentWillUnmount () {
+		clearTimeout(this.hidingTimerId);
 		delete Component.instance
 	}
 


### PR DESCRIPTION
So I am using react-progress-2 in a way where Component containing <Progress.Component/> is sometimes unmounted right after calling Progress.hide().

This results in "Uncaught TypeError: Cannot read property 'setAttribute' of null" from inside setTimeout in https://github.com/milworm/react-progress-2/blob/master/src/main.js#L68, because componentWillUnmount clears other state, but does not cancel setTimeout.

Make componentWillUnmount to clear timeout to avoid this.

